### PR TITLE
Storyboard init and edgesForExtendedLayout fix.

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -78,15 +78,6 @@ static NSString *PDTSimpleCalendarViewHeaderIdentifier = @"com.producteev.collec
     self.overlayTextColor = [UIColor blackColor];
 }
 
-- (void)awakeFromNib {
-    [super awakeFromNib];
-    
-    //iOS7 Only: We don't want the calendar to go below the status bar (&navbar if there is one).
-    if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
-        self.edgesForExtendedLayout = UIRectEdgeNone;
-    }
-}
-
 #pragma mark - Accessors
 
 - (NSDateFormatter *)headerDateFormatter;


### PR DESCRIPTION
Storyboards use `initWithCoder:` so I just copied what you had done in `initWithNibName:` and it worked for me. Without the first change, using storyboards in conjunction with the PDTSimpleCalendarController would cause a crash.

Second, I moved the `edgesForExtendedLayout` initialization to `awakeFromNib` so that the programmer using the controller can override this behavior in places like `prepareForSegue:` as `awakeFromNib` is called before `prepareForSegue:` whereas `viewDidLoad` is called after.
