### PR TITLE
Default to tintColor for selection

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
@@ -174,7 +174,7 @@ const CGFloat PDTSimpleCalendarCircleSize = 32.0f;
         return _circleSelectedColor;
     }
 
-    return [UIColor redColor];
+    return self.tintColor;
 }
 
 #pragma mark - Text Label Customizations Color


### PR DESCRIPTION
Right now this doesn't quite work though. I think the problem is `-circleSelectedColor` gets called before the receiver has been added to the view hierarchy, so it hasn't picked up the app's preferred tint color. Is the intent of this change something you're interested in though?
