### PR TITLE
Fix up scrolling to handle Collection View with content inset

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -199,7 +199,10 @@ static NSString *PDTSimpleCalendarViewHeaderIdentifier = @"com.producteev.collec
 
     NSIndexPath *indexPath = [self indexPathForCellAtDate:_selectedDate];
     [self.collectionView reloadItemsAtIndexPaths:@[ indexPath ]];
-    [self scrollToDate:_selectedDate animated:animated];
+    
+    if (![self.collectionView.indexPathsForVisibleItems containsObject:indexPath]) {
+        [self scrollToDate:_selectedDate animated:animated];
+    }
 
 	//Deprecated version.
 	//TODO: Remove in next update


### PR DESCRIPTION
Under iOS 7, it's common for collection views to be laid out with a `.contentInset`, such that they appear underneath the nav bar. This renders the existing scrolling logic faulty since it:
- Considers a date which is presently underneath the nav bar to be visible
- Doesn't take the `contentInset` into account when deciding where to scroll to

I've switched the code around a bit to resolve these issues
