### PR TITLE
added full date as accessibility label to PDTSimpleCalendarViewCell

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewCell.m
@@ -21,22 +21,36 @@ const CGFloat PDTSimpleCalendarCircleSize = 32.0f;
 
 #pragma mark - Class Methods
 
-+ (void)formatDate:(NSDate *)date withCalendar:(NSCalendar *)calendar forLabel:(UILabel *)label
++ (NSString *)formatDate:(NSDate *)date withCalendar:(NSCalendar *)calendar
 {
     NSDateFormatter *dateFormatter = [self dateFormatter];
-    dateFormatter.dateFormat = @"d";
-    label.text = [PDTSimpleCalendarViewCell stringFromDate:date withDateFormatter:dateFormatter withCalendar:calendar];
-    
-    [dateFormatter setDateStyle:NSDateFormatterLongStyle];
-    [dateFormatter setTimeStyle:NSDateFormatterNoStyle];
-    label.accessibilityLabel =  [PDTSimpleCalendarViewCell stringFromDate:date withDateFormatter:dateFormatter withCalendar:calendar];
+    return [PDTSimpleCalendarViewCell stringFromDate:date withDateFormatter:dateFormatter withCalendar:calendar];
 }
+
++ (NSString *)formatAccessibilityDate:(NSDate *)date withCalendar:(NSCalendar *)calendar
+{
+    NSDateFormatter *dateFormatter = [self accessibilityDateFormatter];
+    return [PDTSimpleCalendarViewCell stringFromDate:date withDateFormatter:dateFormatter withCalendar:calendar];
+}
+
 
 + (NSDateFormatter *)dateFormatter {
     static NSDateFormatter *dateFormatter;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.dateFormat = @"d";
+    });
+    return dateFormatter;
+}
+
++ (NSDateFormatter *)accessibilityDateFormatter {
+    static NSDateFormatter *dateFormatter;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateStyle:NSDateFormatterLongStyle];
+        [dateFormatter setTimeStyle:NSDateFormatterNoStyle];
         
     });
     return dateFormatter;
@@ -82,10 +96,15 @@ const CGFloat PDTSimpleCalendarCircleSize = 32.0f;
 
 - (void)setDate:(NSDate *)date calendar:(NSCalendar *)calendar
 {
+    NSString* day = @"";
+    NSString* accessibilityDay = @"";
     if (date && calendar) {
         _date = date;
+        day = [PDTSimpleCalendarViewCell formatDate:date withCalendar:calendar];
+        accessibilityDay = [PDTSimpleCalendarViewCell formatAccessibilityDate:date withCalendar:calendar];
     }
-    [PDTSimpleCalendarViewCell formatDate:date withCalendar:calendar forLabel:self.dayLabel];
+    self.dayLabel.text = day;
+    self.dayLabel.accessibilityLabel = accessibilityDay;
 }
 
 - (void)setIsToday:(BOOL)isToday


### PR DESCRIPTION
I've added the full date as an accessibilityLabel to the individual dates in your calendar. 

This means that when you tap a date with VoiceOver enabled, instead of just reading the date of the month (eg. 29), the ever so friendly VoiceOver assistent now reads October 29, 2014.

I've taken the liberty of extracting the creation of a DateFormatter to a separate method, which is then used from both the old

```
formatDate: withCalendar:
```

method, and from the new

```
accessibilityFriendlyStringFromDate: withCalendar:
```

Having set the DateFormatter as these methods need, they both call the new (extracted) method

```
stringFromDate: withDateFormatter: withCalendar:
```

Accessibility is enabled for the dayLabel in the

```
initWithFrame: 
```

method and finally, the accessibilityLabel is populated in

```
setDate: calendar:
```

And that's pretty much it. 
