### PR TITLE
Use __tg_fabs() instead of fabs().

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -11,7 +11,7 @@
 #import "PDTSimpleCalendarViewFlowLayout.h"
 #import "PDTSimpleCalendarViewCell.h"
 #import "PDTSimpleCalendarViewHeader.h"
-
+#import <tgmath.h>
 
 const CGFloat PDTSimpleCalendarOverlaySize = 14.0f;
 
@@ -413,7 +413,7 @@ static NSString *PDTSimpleCalendarViewHeaderIdentifier = @"com.producteev.collec
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
 {
     //We only display the overlay view if there is a vertical velocity
-    if ( fabsf(velocity.y) > 0.0f) {
+    if ( __tg_fabs(velocity.y) > 0.0f) {
         if (self.overlayView.alpha < 1.0) {
             [UIView animateWithDuration:0.25 animations:^{
                 [self.overlayView setAlpha:1.0];


### PR DESCRIPTION
__tg_fabs uses overloading in clang (even in C) to work with float or double, since a CGFloat is a float on 32-bit and a double on 64-bit.