### PR TITLE
Disable Selection Property

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.h
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.h
@@ -65,6 +65,13 @@
 @property (nonatomic, assign) BOOL weekdayHeaderEnabled;
 
 /**
+ *  Setting this to YES disables the ability to select a date
+ *
+ *  Default value is NO.
+ */
+@property (nonatomic, assign) BOOL dateSelectionDisabled;
+
+/**
  *  Setting Text type of weekday
  *
  *  Default value is Short.

--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -412,6 +412,10 @@ static const NSCalendarUnit kCalendarUnitYMD = NSCalendarUnitYear | NSCalendarUn
 
 - (BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (self.dateSelectionDisabled) {
+        return NO;
+    }
+
     NSDate *firstOfMonth = [self firstOfMonthForSection:indexPath.section];
     NSDate *cellDate = [self dateForCellAtIndexPath:indexPath];
 


### PR DESCRIPTION
Not every calendar needs to be selectable or want to change the color based on selection.  Similar to issue [#75](https://github.com/jivesoftware/PDTSimpleCalendar/issues/75) this feature gives the ability to disable color selection for a calendar.
