### PR TITLE
Multiple selection and custom cell feature

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.h
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.h
@@ -154,4 +154,23 @@
  */
 - (UIColor *)simpleCalendarViewController:(PDTSimpleCalendarViewController *)controller textColorForDate:(NSDate *)date;
 
+/** @name Date cell Customization */
+
+/**
+ *  Asks the delegate custom date cell
+ *
+ *  @return Customized date cell should be inherited from `PSTSimpleCalenderViewCell`
+ */
+- (Class)customCollectionViewCellClass;
+
+/**
+ *  Give delegate a chance to manipulate custom date cell
+ *
+ *  @param cell the calendarView cell
+ *  @param date the date of cell
+ *
+ *  @return YES if the calendar must ask the delegate for text and circle color, NO if it should use default values.
+ */
+- (void)customCellManipulate:(UICollectionViewCell * __nonnull)cell withDate:( NSDate * _Nullable )date;
+
 @end;

--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -206,7 +206,7 @@ static const NSCalendarUnit kCalendarUnitYMD = NSCalendarUnitYear | NSCalendarUn
         return;
     }
 
-    // TODO:
+    // Don't clear other cell circle if collectionView in multipleSelection mode 
     if (!self.collectionView.allowsMultipleSelection) {
         [[self cellForItemAtDate:_selectedDate] setSelected:NO];
         [[self cellForItemAtDate:startOfDay] setSelected:YES];


### PR DESCRIPTION
Add two method to `PDTSimpleCalendarViewDelegate` give `PDTSimpleCalendar` ability using multiple selection and custom cell.

using multiple selection via  `collectionView.allowsMultipleSelection = true`
using custom cell by implement new delegate method
