### PR TITLE
Implemented a fix to allow programmatic invokation of storyboard segues.

### DIFF
--- a/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
+++ b/PDTSimpleCalendar/PDTSimpleCalendarViewController.m
@@ -61,6 +61,7 @@ static const NSCalendarUnit kCalendarUnitYMD = NSCalendarUnitYear | NSCalendarUn
 {
     //Force the creation of the view with the pre-defined Flow Layout.
     //Still possible to define a custom Flow Layout, if needed by using initWithCollectionViewLayout:
+    self = [super initWithCoder:coder];
     self = [super initWithCollectionViewLayout:[[PDTSimpleCalendarViewFlowLayout alloc] init]];
     if (self) {
         // Custom initialization


### PR DESCRIPTION
Added a call to super's initWithCoder method within PDTSimpleCalendarViewController's initWithCoder method.

Without this fix a call within a subclass of PDTSimpleCalendarViewController to self.performSegueWithIdentifier(identifier: String, sender: AnyObject?) fails saying that no segue exists with the identifier.
